### PR TITLE
Fix method overwritten warning on julia master

### DIFF
--- a/src/LibSndFile.jl
+++ b/src/LibSndFile.jl
@@ -88,8 +88,6 @@ type SndFileSink <: SampleSink
     sfinfo::SF_INFO
 end
 
-SndFileSink(filePtr, sfinfo) = SndFileSink(filePtr, sfinfo)
-
 nchannels(sink::SndFileSink) = Int(sink.sfinfo.channels)
 samplerate(sink::SndFileSink) = quantity(Int, Hz)(sink.sfinfo.samplerate)
 Base.eltype(sink::SndFileSink) = fmt_to_type(sink.sfinfo.format)


### PR DESCRIPTION
The exact warning is as follows:

```jl
julia> using LibSndFile
INFO: Recompiling stale cache file /Users/ryuyamamoto/.julia/lib/v0.5/LibSndFile.ji for module LibSndFile.
WARNING: Method definition (::Type{LibSndFile.SndFileSink})(Any, Any) in
module LibSndFile at /Users/ryuyamamoto/.julia/v0.5/LibSndFile/src/LibSndFile.jl:91 overwritten at /Users/ryuyamamoto/.julia/v0.5/LibSndFile/src/LibSndFile.jl:95.
```