### PR TITLE
Import and export `load` and `save` explicitly

### DIFF
--- a/src/LibSndFile.jl
+++ b/src/LibSndFile.jl
@@ -5,11 +5,15 @@ module LibSndFile
 using SampleTypes
 import SampleTypes: nchannels, nframes, samplerate, unsafe_read!, unsafe_write
 using FileIO
+import FileIO: load, save
 using FixedPointNumbers
 using SIUnits
 
 # TODO: move these into FileIO.jl
 export loadstream, savestream
+
+# Re-export from FileIO
+export load, save
 
 typealias PCM16Sample Fixed{Int16, 15}
 typealias PCM32Sample Fixed{Int32, 31}
@@ -101,7 +105,6 @@ type SndFileSource{T} <: SampleSource
     readbuf::Array{T, 2}
     transbuf::Array{T, 2}
 end
-
 
 function SndFileSource(filePtr, sfinfo, bufsize=4096)
     T = fmt_to_type(sfinfo.format)


### PR DESCRIPTION
to avoid errors when users (at least me) call `load` or `save` without using FileIO.

Before:

```jl
Julia> using LibSndFile
julia> x = load("../WORLD/test/data/test16k.wav")
ERROR: UndefVarError: load not defined
 in eval(::Module, ::Any) at ./boot.jl:267
```

After:

```jl
julia> using LibSndFile
julia> x = load("../WORLD/test/data/test16k.wav")
60700-frame, 1-channel SampleBuf{FixedPointNumbers.Fixed{Int16,15}, 2,
SIUnits.SIQuantity{Int64,0,0,-1,0,0,0,0,0,0}}
3.79375 s at 16000 s⁻¹
▁▅▆▇▇▇▇▇▇▇▇▇▇▇▆▆▆▅▄▆▆▆▆▆▅▂▂▂▁▂▂▁▁▁▃▄▅▆▆▇▇▅▆▆▅▆▆▆▇▆▆▇▇▅▆▇▇▇▆▆▆▆▆▆▆▇▇▇▇▆▇▇▇▆▆▆▆▅▃▂
```