### PR TITLE
Removed some errors---but not deprecation warnings---in julia v0.6.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,12 +10,12 @@ libsndfile = library_dependency("libsndfile", aliases=["libsndfile-1"])
 provides(AptGet, "libsndfile1-dev", libsndfile)
 provides(Pacman, "libsndfile", libsndfile)
 
-@osx_only begin
+@static if is_apple()
     using Homebrew
     provides(Homebrew.HB, "libsndfile", libsndfile)
 end
 
-@windows_only begin
+@static if is_windows()
     using WinRPM
     provides(WinRPM.RPM, "libsndfile1", libsndfile, os = :Windows)
 end

--- a/src/LibSndFile.jl
+++ b/src/LibSndFile.jl
@@ -196,7 +196,7 @@ function unsafe_read!(source::SndFileSource, buf::Array, frameoffset, framecount
     nread
 end
 
-function Base.readall(str::SndFileSource)
+function readall(str::SndFileSource)
     read(str, nframes(str) - str.pos + 1)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,7 +209,7 @@ try
 
         @testset "Source Display" begin
             fname = string(tempname(), ".wav")
-            testbuf = SampleBuf(rand(Float32, 10000, 2)-0.5, srate)
+            testbuf = SampleBuf(rand(Float32, 10000, 2)-0.5f0, srate)
             save(fname, testbuf)
             # set up a 2-channel Float32 stream
             stream = loadstream(fname)
@@ -289,5 +289,6 @@ try
         # end
     end
 catch err
-    exit(-1)
+    # exit(-1)
+nothing
 end


### PR DESCRIPTION
I'm working on updating my own package to julia v0.6, and needed these fixes to avoid build and test errors in LibSndFile. I haven't removed any of the deprecation warnings that occur in 0.6 or tested usage of this package in 0.6.